### PR TITLE
Tidy up to get ready for a release soon

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,15 @@ Wii Motion Plus support is planned, both in standalone and combo mode
 
 ## Usage
 
-To use this driver, import this crate and an `embedded_hal` implementation,
+To use this driver, import this crate and an `embedded_hal`/`embedded_hal_async` implementation,
 then instantiate the appropriate device.
 
 ```rust
 use ::I2C; // insert an include for your HAL i2c peripheral name here
-use wii_ext::classic_sync::Classic; // use the synchronous/blocking driver
-// use wii_ext::classic_sync::Classic; // use the synchronous/blocking driver
+// use the synchronous/blocking driver
+use wii_ext::blocking_impl::classic::Classic;
+// use the asynchronous driver
+// use wii_ext::async_impl::classic::Classic;
 
 fn main() {
     let i2c = I2C::new(); // insert your HAL i2c init here

--- a/examples/embassy-rp-async/src/main.rs
+++ b/examples/embassy-rp-async/src/main.rs
@@ -4,7 +4,7 @@
 use defmt::*;
 use embassy_rp::gpio;
 use gpio::{Level, Output};
-use wii_ext::classic_async;
+use wii_ext::async_impl::classic::Classic;
 use {defmt_rtt as _, panic_probe as _};
 
 use embassy_executor::Spawner;
@@ -43,7 +43,7 @@ async fn main(spawner: Spawner) {
 
     // Create, initialise and calibrate the controller
     info!("initialising controller");
-    let mut controller = classic_async::ClassicAsync::new(i2c, Delay);
+    let mut controller = Classic::new(i2c, Delay);
     controller.init().await.unwrap();
 
     let hi_res = false;

--- a/examples/nunchuk-async-embassy-rp/src/main.rs
+++ b/examples/nunchuk-async-embassy-rp/src/main.rs
@@ -4,7 +4,7 @@
 use defmt::*;
 use embassy_rp::gpio;
 use gpio::{Level, Output};
-use wii_ext::async_impl::nunchuk;
+use wii_ext::async_impl::nunchuk::Nunchuk;
 use {defmt_rtt as _, panic_probe as _};
 
 use embassy_executor::Spawner;
@@ -15,7 +15,6 @@ use embassy_rp::peripherals::I2C0;
 use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
 use embassy_sync::mutex::Mutex;
 use embassy_time::{Delay, Duration, Ticker};
-use embassy_time::Timer;
 
 bind_interrupts!(struct Irqs {
     I2C0_IRQ => InterruptHandler<I2C0>;
@@ -44,9 +43,8 @@ async fn main(spawner: Spawner) {
 
     // Create, initialise and calibrate the controller
     info!("initialising controller");
-    let mut controller = nunchuk::NunchukAsync::new(i2c, Delay);
+    let mut controller = Nunchuk::new(i2c, Delay);
     controller.init().await.unwrap();
-
 
     info!("begin polling controller");
     loop {

--- a/examples/rp2040-hal-blocking/src/main.rs
+++ b/examples/rp2040-hal-blocking/src/main.rs
@@ -14,7 +14,7 @@ use bsp::hal::{
 use embedded_hal::delay::DelayNs;
 use fugit::RateExtU32;
 use rp_pico as bsp;
-use wii_ext::classic_sync::Classic;
+use wii_ext::blocking_impl::classic::Classic;
 
 #[entry]
 fn main() -> ! {
@@ -76,7 +76,7 @@ fn main() -> ! {
         delay.delay_ms(10);
 
         // Capture the current button and axis values
-        let input = controller.read_blocking();
+        let input = controller.read();
         if let Ok(input) = input {
             // Print inputs from the controller
             debug!("{:?}", input);

--- a/wii-ext/Cargo.toml
+++ b/wii-ext/Cargo.toml
@@ -19,3 +19,6 @@ paste = "1.0.6"
 [features]
 default = ["defmt_print"]
 defmt_print = ["defmt"]
+
+[lib]
+doctest = false

--- a/wii-ext/src/async_impl.rs
+++ b/wii-ext/src/async_impl.rs
@@ -1,6 +1,6 @@
-/// Async classic controller code
+/// Async classic controller driver
 pub mod classic;
 /// Async i2c interface code
 pub mod interface;
-
+/// Async nunchuk controller driver
 pub mod nunchuk;

--- a/wii-ext/src/async_impl/classic.rs
+++ b/wii-ext/src/async_impl/classic.rs
@@ -40,6 +40,11 @@ where
         }
     }
 
+    /// Recover data members
+    pub fn destroy(self) -> (I2C, Delay) {
+        self.interface.destroy()
+    }
+
     // / Update the stored calibration for this controller
     // /
     // / Since each device will have different tolerances, we take a snapshot of some analog data

--- a/wii-ext/src/async_impl/classic.rs
+++ b/wii-ext/src/async_impl/classic.rs
@@ -3,13 +3,13 @@ use crate::core::classic::*;
 use crate::core::ControllerType;
 use embedded_hal_async;
 
-pub struct ClassicAsync<I2C, Delay> {
+pub struct Classic<I2C, Delay> {
     interface: InterfaceAsync<I2C, Delay>,
     hires: bool,
     calibration: CalibrationData,
 }
 
-impl<I2C, Delay> ClassicAsync<I2C, Delay>
+impl<I2C, Delay> Classic<I2C, Delay>
 where
     I2C: embedded_hal_async::i2c::I2c,
     Delay: embedded_hal_async::delay::DelayNs,

--- a/wii-ext/src/async_impl/interface.rs
+++ b/wii-ext/src/async_impl/interface.rs
@@ -48,6 +48,11 @@ where
         Self { i2cdev, delay }
     }
 
+    /// Recover data members
+    pub fn destroy(self) -> (I2C, Delay) {
+        (self.i2cdev, self.delay)
+    }
+
     pub(super) async fn delay_us(&mut self, micros: u32) {
         self.delay.delay_us(micros).await
     }

--- a/wii-ext/src/async_impl/interface.rs
+++ b/wii-ext/src/async_impl/interface.rs
@@ -1,15 +1,3 @@
-// See https://www.raphnet-tech.com/support/classic_controller_high_res/ for data on high-precision mode
-
-// Abridged version of the above:
-// To enable High Resolution Mode, you simply write 0x03 to address 0xFE in the extension controller memory.
-// Then you poll the controller by reading 8 bytes at address 0x00 instead of only 6.
-// You can also restore the original format by writing the original value back to address 0xFE at any time.
-//
-// Classic mode:
-// http://wiibrew.org/wiki/Wiimote/Extension_Controllers/Classic_Controller
-//
-// See `decode_classic_report` and `decode_classic_hd_report` for data format
-
 use crate::core::{
     ControllerIdReport, ControllerType, ExtHdReport, ExtReport, EXT_I2C_ADDR,
     INTERMESSAGE_DELAY_MICROSEC_U32,
@@ -33,31 +21,27 @@ pub struct InterfaceAsync<I2C, Delay> {
     delay: Delay,
 }
 
-// use crate::nunchuk;
 impl<I2C, Delay> InterfaceAsync<I2C, Delay>
 where
     I2C: embedded_hal_async::i2c::I2c,
     Delay: embedded_hal_async::delay::DelayNs,
 {
-    /// Create a new Wii Nunchuck
-    ///
-    /// This method will open the provide i2c device file and will
-    /// send the required init sequence in order to read data in
-    /// the future.
+    /// Create async interface for wii-extension controller
     pub fn new(i2cdev: I2C, delay: Delay) -> Self {
         Self { i2cdev, delay }
     }
 
-    /// Recover data members
+    /// Destroy i2c interface, allowing recovery of i2c and delay
     pub fn destroy(self) -> (I2C, Delay) {
         (self.i2cdev, self.delay)
     }
 
+    /// Access delay stored in interface
     pub(super) async fn delay_us(&mut self, micros: u32) {
         self.delay.delay_us(micros).await
     }
 
-    /// Read the button/axis data from the classic controller
+    /// Read report data from the wii-extension controller
     pub(super) async fn read_ext_report(&mut self) -> Result<ExtReport, AsyncImplError> {
         self.start_sample().await?;
         self.delay_us(INTERMESSAGE_DELAY_MICROSEC_U32).await;
@@ -69,7 +53,7 @@ where
             .and(Ok(buffer))
     }
 
-    /// Read a high-resolution version of the button/axis data from the classic controller
+    /// Read a high-resolution version of the report data from the wii-extension controller
     pub(super) async fn read_hd_report(&mut self) -> Result<ExtHdReport, AsyncImplError> {
         self.start_sample().await?;
         self.delay_us(INTERMESSAGE_DELAY_MICROSEC_U32).await;
@@ -82,8 +66,6 @@ where
     }
 
     /// Send the init sequence to the Wii extension controller
-    ///
-    /// This could be a bit faster with DelayUs, but since you only init once we'll re-use delay_ms
     pub(super) async fn init(&mut self) -> Result<(), AsyncImplError> {
         // Extension controllers by default will use encrypted communication, as that is what the Wii does.
         // We can disable this encryption by writing some magic values
@@ -101,7 +83,7 @@ where
 
     /// Switch the driver from standard to hi-resolution reporting
     ///
-    /// This enables the controllers high-resolution report data mode, which returns each
+    /// This enables the controller's high-resolution report data mode, which returns each
     /// analogue axis as a u8, rather than packing smaller integers in a structure.
     /// If your controllers supports this mode, you should use it. It is much better.
     pub(super) async fn enable_hires(&mut self) -> Result<(), AsyncImplError> {
@@ -127,6 +109,13 @@ where
             .and(Ok(()))
     }
 
+    /// Set the cursor position for the next i2c read after a small delay
+    ///
+    /// This hardware has a range of 100 registers and automatically
+    /// increments the register read postion on each read operation, and also on
+    /// every write operation.
+    /// This should be called before a read operation to ensure you get the correct data
+    /// The delay helps ensure that required timings are met
     pub(super) async fn set_read_register_address_with_delay(
         &mut self,
         byte0: u8,
@@ -145,6 +134,7 @@ where
             .and(Ok(()))
     }
 
+    /// Set a single register at target address after a small delay
     pub(super) async fn set_register_with_delay(
         &mut self,
         addr: u8,
@@ -155,12 +145,14 @@ where
         res.await
     }
 
+    /// Read the controller type ID register from the extension controller
     pub(super) async fn read_id(&mut self) -> Result<ControllerIdReport, AsyncImplError> {
         self.set_read_register_address(0xfa).await?;
         let i2c_id = self.read_ext_report().await?;
         Ok(i2c_id)
     }
 
+    /// Determine the controller type based on the type ID of the extension controller
     pub(super) async fn identify_controller(
         &mut self,
     ) -> Result<Option<ControllerType>, AsyncImplError> {
@@ -168,7 +160,7 @@ where
         Ok(crate::core::identify_controller(i2c_id))
     }
 
-    /// tell the extension controller to prepare a sample by setting the read cursor to 0
+    /// Instruct the extension controller to start preparing a sample by setting the read cursor to 0
     pub(super) async fn start_sample(&mut self) -> Result<(), AsyncImplError> {
         self.set_read_register_address(0x00).await?;
         Ok(())

--- a/wii-ext/src/async_impl/nunchuk.rs
+++ b/wii-ext/src/async_impl/nunchuk.rs
@@ -1,14 +1,6 @@
-// The nunchuk portion of this crate is derived from
-// https://github.com/rust-embedded/rust-i2cdev/blob/master/examples/nunchuck.rs
-// which is Copyright 2015, Paul Osborne <osbpau@gmail.com>
-//
-// All the bugs are Copyright 2024, 9names.
-
-// Nunchuk technically supports HD report, but the last two bytes will be zeroes
-// There's no benefit, so we're leaving that unimplemented
 use crate::async_impl::interface::{AsyncImplError, InterfaceAsync};
 use crate::core::nunchuk::*;
-use crate::core::{ControllerIdReport, ControllerType};
+use crate::core::ControllerType;
 use embedded_hal_async;
 
 pub struct NunchukAsync<I2C, Delay> {
@@ -22,10 +14,6 @@ where
     Delay: embedded_hal_async::delay::DelayNs,
 {
     /// Create a new Wii Nunchuck
-    ///
-    /// This method will open the provide i2c device file and will
-    /// send the required init sequence in order to read data in
-    /// the future.
     pub fn new(i2cdev: I2C, delay: Delay) -> Self {
         let interface = InterfaceAsync::new(i2cdev, delay);
         Self {
@@ -34,7 +22,7 @@ where
         }
     }
 
-    /// Recover data members
+    /// Destroy this driver, recovering the i2c bus and delay used to create it
     pub fn destroy(self) -> (I2C, Delay) {
         self.interface.destroy()
     }
@@ -52,16 +40,8 @@ where
         Ok(())
     }
 
-    /// Send the init sequence to the Wii extension controller
-    ///
-    /// This could be a bit faster with DelayUs, but since you only init once we'll re-use delay_ms
+    /// Send the init sequence to the controller and calibrate it
     pub async fn init(&mut self) -> Result<(), AsyncImplError> {
-        // Extension controllers by default will use encrypted communication, as that is what the Wii does.
-        // We can disable this encryption by writing some magic values
-        // This is described at https://wiibrew.org/wiki/Wiimote/Extension_Controllers#The_New_Way
-
-        // Reset to base register first - this should recover a controller in a weird state.
-        // Use longer delays here than normal reads - the system seems more unreliable performing these commands
         self.interface.init().await?;
         self.update_calibration().await?;
         Ok(())
@@ -81,10 +61,7 @@ where
         ))
     }
 
-    pub async fn read_id(&mut self) -> Result<ControllerIdReport, AsyncImplError> {
-        self.interface.read_id().await
-    }
-
+    /// Determine the controller type based on the type ID of the extension controller
     pub async fn identify_controller(&mut self) -> Result<Option<ControllerType>, AsyncImplError> {
         self.interface.identify_controller().await
     }

--- a/wii-ext/src/async_impl/nunchuk.rs
+++ b/wii-ext/src/async_impl/nunchuk.rs
@@ -34,6 +34,11 @@ where
         }
     }
 
+    /// Recover data members
+    pub fn destroy(self) -> (I2C, Delay) {
+        self.interface.destroy()
+    }
+
     /// Update the stored calibration for this controller
     ///
     /// Since each device will have different tolerances, we take a snapshot of some analog data

--- a/wii-ext/src/async_impl/nunchuk.rs
+++ b/wii-ext/src/async_impl/nunchuk.rs
@@ -3,12 +3,12 @@ use crate::core::nunchuk::*;
 use crate::core::ControllerType;
 use embedded_hal_async;
 
-pub struct NunchukAsync<I2C, Delay> {
+pub struct Nunchuk<I2C, Delay> {
     interface: InterfaceAsync<I2C, Delay>,
     calibration: CalibrationData,
 }
 
-impl<I2C, Delay> NunchukAsync<I2C, Delay>
+impl<I2C, Delay> Nunchuk<I2C, Delay>
 where
     I2C: embedded_hal_async::i2c::I2c,
     Delay: embedded_hal_async::delay::DelayNs,

--- a/wii-ext/src/blocking_impl/classic.rs
+++ b/wii-ext/src/blocking_impl/classic.rs
@@ -53,6 +53,11 @@ where
         Ok(classic)
     }
 
+    /// Recover data members
+    pub fn destroy(self) -> (T, DELAY) {
+        self.interface.destroy()
+    }
+
     /// Update the stored calibration for this controller
     ///
     /// Since each device will have different tolerances, we take a snapshot of some analog data

--- a/wii-ext/src/blocking_impl/classic.rs
+++ b/wii-ext/src/blocking_impl/classic.rs
@@ -1,15 +1,3 @@
-// See https://www.raphnet-tech.com/support/classic_controller_high_res/ for data on high-precision mode
-
-// Abridged version of the above:
-// To enable High Resolution Mode, you simply write 0x03 to address 0xFE in the extension controller memory.
-// Then you poll the controller by reading 8 bytes at address 0x00 instead of only 6.
-// You can also restore the original format by writing the original value back to address 0xFE at any time.
-//
-// Classic mode:
-// http://wiibrew.org/wiki/Wiimote/Extension_Controllers/Classic_Controller
-//
-// See `decode_classic_report` and `decode_classic_hd_report` for data format
-
 use crate::blocking_impl::interface::{BlockingImplError, Interface};
 use crate::core::classic::{CalibrationData, ClassicReading, ClassicReadingCalibrated};
 use crate::core::ControllerType;
@@ -37,11 +25,7 @@ where
     T: I2c<SevenBitAddress, Error = E>,
     DELAY: embedded_hal::delay::DelayNs,
 {
-    /// Create a new Wii Nunchuck
-    ///
-    /// This method will open the provide i2c device file and will
-    /// send the required init sequence in order to read data in
-    /// the future.
+    /// Create a new Wii Classic Controller
     pub fn new(i2cdev: T, delay: DELAY) -> Result<Classic<T, DELAY>, BlockingImplError<E>> {
         let interface = Interface::new(i2cdev, delay);
         let mut classic = Classic {
@@ -53,7 +37,7 @@ where
         Ok(classic)
     }
 
-    /// Recover data members
+    /// Destroy this driver, recovering the i2c bus and delay used to create it
     pub fn destroy(self) -> (T, DELAY) {
         self.interface.destroy()
     }
@@ -63,7 +47,7 @@ where
     /// Since each device will have different tolerances, we take a snapshot of some analog data
     /// to use as the "baseline" center.
     pub fn update_calibration(&mut self) -> Result<(), BlockingImplError<E>> {
-        let data = self.read_report_blocking()?;
+        let data = self.read_uncalibrated()?;
 
         self.calibration = CalibrationData {
             joystick_left_x: data.joystick_left_x,
@@ -76,19 +60,10 @@ where
         Ok(())
     }
 
-    /// Send the init sequence to the Wii extension controller
-    ///
-    /// This could be a bit faster with DelayNs, but since you only init once we'll re-use delay_ms
+    /// Send the init sequence to the controller
     pub fn init(&mut self) -> Result<(), BlockingImplError<E>> {
-        // Extension controllers by default will use encrypted communication, as that is what the Wii does.
-        // We can disable this encryption by writing some magic values
-        // This is described at https://wiibrew.org/wiki/Wiimote/Extension_Controllers#The_New_Way
-
-        // Reset to base register first - this should recover a controller in a weird state.
-        // Use longer delays here than normal reads - the system seems more unreliable performing these commands
         self.interface.init()?;
         self.update_calibration()?;
-        // TODO: do we need more delay here?
         Ok(())
     }
 
@@ -120,12 +95,14 @@ where
         Ok(())
     }
 
+    /// Determine the controller type based on the type ID of the extension controller
     pub fn identify_controller(&mut self) -> Result<Option<ControllerType>, BlockingImplError<E>> {
         self.interface.identify_controller()
     }
 
-    /// poll the controller for the latest data
-    fn read_classic_report(&mut self) -> Result<ClassicReading, BlockingImplError<E>> {
+    /// Do a read, and return button and axis values without applying calibration
+    pub fn read_uncalibrated(&mut self) -> Result<ClassicReading, BlockingImplError<E>> {
+        self.interface.start_sample_and_wait()?;
         if self.hires {
             let buf = self.interface.read_hd_report()?;
             ClassicReading::from_data(&buf).ok_or(BlockingImplError::InvalidInputData)
@@ -135,22 +112,10 @@ where
         }
     }
 
-    /// Simple read helper helper with no delay. Works for testing, not on real hardware
-    pub fn read_classic_no_wait(&mut self) -> Result<ClassicReading, BlockingImplError<E>> {
-        self.interface.start_sample()?;
-        self.read_classic_report()
-    }
-
-    /// Simple blocking read helper that will start a sample, wait 10ms, then read the value
-    pub fn read_report_blocking(&mut self) -> Result<ClassicReading, BlockingImplError<E>> {
-        self.interface.start_sample_and_wait()?;
-        self.read_classic_report()
-    }
-
-    /// Do a read, and report axis values relative to calibration
-    pub fn read_blocking(&mut self) -> Result<ClassicReadingCalibrated, BlockingImplError<E>> {
+    /// Do a read, and return button and axis values relative to calibration
+    pub fn read(&mut self) -> Result<ClassicReadingCalibrated, BlockingImplError<E>> {
         Ok(ClassicReadingCalibrated::new(
-            self.read_report_blocking()?,
+            self.read_uncalibrated()?,
             &self.calibration,
         ))
     }

--- a/wii-ext/src/blocking_impl/interface.rs
+++ b/wii-ext/src/blocking_impl/interface.rs
@@ -55,9 +55,7 @@ where
         Ok(i2c_id)
     }
 
-    pub(super) fn identify_controller(
-        &mut self,
-    ) -> Result<Option<ControllerType>, BlockingImplError<E>> {
+    pub(super) fn identify_controller(&mut self) -> Result<Option<ControllerType>, BlockingImplError<E>> {
         let i2c_id = self.read_id()?;
         Ok(crate::core::identify_controller(i2c_id))
     }
@@ -81,10 +79,7 @@ where
     /// increments the register read postion on each read operation, and also on
     /// every write operation.
     /// This should be called before a read operation to ensure you get the correct data
-    pub(super) fn set_read_register_address(
-        &mut self,
-        byte0: u8,
-    ) -> Result<(), BlockingImplError<E>> {
+    pub(super) fn set_read_register_address(&mut self, byte0: u8) -> Result<(), BlockingImplError<E>> {
         self.i2cdev
             .write(EXT_I2C_ADDR as u8, &[byte0])
             .map_err(BlockingImplError::I2C)

--- a/wii-ext/src/blocking_impl/interface.rs
+++ b/wii-ext/src/blocking_impl/interface.rs
@@ -48,9 +48,6 @@ where
         self.delay.delay_us(INTERMESSAGE_DELAY_MICROSEC * 2);
         self.set_register(0xFB, 0x00)?;
         self.delay.delay_us(INTERMESSAGE_DELAY_MICROSEC * 2);
-        // TODO: move calibration to each impl
-        //self.update_calibration()?;
-        self.delay.delay_us(INTERMESSAGE_DELAY_MICROSEC * 2);
         Ok(())
     }
 
@@ -60,6 +57,7 @@ where
         Ok(i2c_id)
     }
 
+    /// Determine the controller type based on the type ID of the extension controller
     pub(super) fn identify_controller(
         &mut self,
     ) -> Result<Option<ControllerType>, BlockingImplError<E>> {
@@ -135,5 +133,4 @@ where
             .map_err(BlockingImplError::I2C)
             .and(Ok(buffer))
     }
-
 }

--- a/wii-ext/src/blocking_impl/interface.rs
+++ b/wii-ext/src/blocking_impl/interface.rs
@@ -28,6 +28,11 @@ where
         Interface { i2cdev, delay }
     }
 
+    /// Recover data members
+    pub fn destroy(self) -> (I2C, Delay) {
+        (self.i2cdev, self.delay)
+    }
+
     /// Send the init sequence to the Wii extension controller
     pub(super) fn init(&mut self) -> Result<(), BlockingImplError<E>> {
         // Extension controllers by default will use encrypted communication, as that is what the Wii does.
@@ -130,4 +135,5 @@ where
             .map_err(BlockingImplError::I2C)
             .and(Ok(buffer))
     }
+
 }

--- a/wii-ext/src/blocking_impl/interface.rs
+++ b/wii-ext/src/blocking_impl/interface.rs
@@ -55,7 +55,9 @@ where
         Ok(i2c_id)
     }
 
-    pub(super) fn identify_controller(&mut self) -> Result<Option<ControllerType>, BlockingImplError<E>> {
+    pub(super) fn identify_controller(
+        &mut self,
+    ) -> Result<Option<ControllerType>, BlockingImplError<E>> {
         let i2c_id = self.read_id()?;
         Ok(crate::core::identify_controller(i2c_id))
     }
@@ -79,7 +81,10 @@ where
     /// increments the register read postion on each read operation, and also on
     /// every write operation.
     /// This should be called before a read operation to ensure you get the correct data
-    pub(super) fn set_read_register_address(&mut self, byte0: u8) -> Result<(), BlockingImplError<E>> {
+    pub(super) fn set_read_register_address(
+        &mut self,
+        byte0: u8,
+    ) -> Result<(), BlockingImplError<E>> {
         self.i2cdev
             .write(EXT_I2C_ADDR as u8, &[byte0])
             .map_err(BlockingImplError::I2C)

--- a/wii-ext/src/blocking_impl/nunchuk.rs
+++ b/wii-ext/src/blocking_impl/nunchuk.rs
@@ -43,6 +43,11 @@ where
         Ok(nunchuk)
     }
 
+    /// Recover data members
+    pub fn destroy(self) -> (I2C, DELAY) {
+        self.interface.destroy()
+    }
+
     /// Update the stored calibration for this controller
     ///
     /// Since each device will have different tolerances, we take a snapshot of some analog data
@@ -91,4 +96,5 @@ where
             &self.calibration,
         ))
     }
+
 }

--- a/wii-ext/src/blocking_impl/nunchuk.rs
+++ b/wii-ext/src/blocking_impl/nunchuk.rs
@@ -66,7 +66,9 @@ where
         self.update_calibration()
     }
 
-    pub fn identify_controller(&mut self) -> Result<Option<ControllerType>, BlockingImplError<ERR>> {
+    pub fn identify_controller(
+        &mut self,
+    ) -> Result<Option<ControllerType>, BlockingImplError<ERR>> {
         self.interface.identify_controller()
     }
 

--- a/wii-ext/src/blocking_impl/nunchuk.rs
+++ b/wii-ext/src/blocking_impl/nunchuk.rs
@@ -66,9 +66,7 @@ where
         self.update_calibration()
     }
 
-    pub fn identify_controller(
-        &mut self,
-    ) -> Result<Option<ControllerType>, BlockingImplError<ERR>> {
+    pub fn identify_controller(&mut self) -> Result<Option<ControllerType>, BlockingImplError<ERR>> {
         self.interface.identify_controller()
     }
 

--- a/wii-ext/src/blocking_impl/nunchuk.rs
+++ b/wii-ext/src/blocking_impl/nunchuk.rs
@@ -1,12 +1,3 @@
-// The nunchuk portion of this crate is derived from
-// https://github.com/rust-embedded/rust-i2cdev/blob/master/examples/nunchuck.rs
-// which is Copyright 2015, Paul Osborne <osbpau@gmail.com>
-//
-// All the bugs are Copyright 2021, 9names.
-
-// TODO: nunchuk technically supports HD report, but the last two bytes will be zeroes
-// work out if it's worth supporting that
-
 use crate::blocking_impl::interface::{BlockingImplError, Interface};
 use crate::core::nunchuk::{CalibrationData, NunchukReading, NunchukReadingCalibrated};
 use crate::core::ControllerType;
@@ -29,10 +20,6 @@ where
     DELAY: embedded_hal::delay::DelayNs,
 {
     /// Create a new Wii Nunchuk
-    ///
-    /// This method will open the provide i2c device file and will
-    /// send the required init sequence in order to read data in
-    /// the future.
     pub fn new(i2cdev: I2C, delay: DELAY) -> Result<Nunchuk<I2C, DELAY>, BlockingImplError<ERR>> {
         let interface = Interface::new(i2cdev, delay);
         let mut nunchuk = Nunchuk {
@@ -43,7 +30,7 @@ where
         Ok(nunchuk)
     }
 
-    /// Recover data members
+    /// Destroy this driver, recovering the i2c bus and delay used to create it
     pub fn destroy(self) -> (I2C, DELAY) {
         self.interface.destroy()
     }
@@ -53,7 +40,7 @@ where
     /// Since each device will have different tolerances, we take a snapshot of some analog data
     /// to use as the "baseline" center.
     pub fn update_calibration(&mut self) -> Result<(), BlockingImplError<ERR>> {
-        let data = self.read_report_blocking()?;
+        let data = self.read_uncalibrated()?;
 
         self.calibration = CalibrationData {
             joystick_x: data.joystick_x,
@@ -62,39 +49,31 @@ where
         Ok(())
     }
 
-    /// Send the init sequence to the Wii extension controller
+    /// Send the init sequence to the Nunchuk
     pub fn init(&mut self) -> Result<(), BlockingImplError<ERR>> {
-        // These registers must be written to disable encryption.; the documentation is a bit
-        // lacking but it appears this is some kind of handshake to
-        // perform unencrypted data tranfers
         self.interface.init()?;
         self.update_calibration()
     }
 
+    /// Determine the controller type based on the type ID of the extension controller
     pub fn identify_controller(
         &mut self,
     ) -> Result<Option<ControllerType>, BlockingImplError<ERR>> {
         self.interface.identify_controller()
     }
 
-    /// Read the button/axis data from the nunchuk
-    fn read_nunchuk(&mut self) -> Result<NunchukReading, BlockingImplError<ERR>> {
+    /// Do a read, and return button and axis values without applying calibration
+    pub fn read_uncalibrated(&mut self) -> Result<NunchukReading, BlockingImplError<ERR>> {
+        self.interface.start_sample()?;
         let buf = self.interface.read_report()?;
         NunchukReading::from_data(&buf).ok_or(BlockingImplError::InvalidInputData)
     }
 
-    /// Simple blocking read helper that will start a sample, wait `INTERMESSAGE_DELAY_MICROSEC`, then read the value
-    pub fn read_report_blocking(&mut self) -> Result<NunchukReading, BlockingImplError<ERR>> {
-        self.interface.start_sample()?;
-        self.read_nunchuk()
-    }
-
-    /// Do a read, and report axis values relative to calibration
-    pub fn read_blocking(&mut self) -> Result<NunchukReadingCalibrated, BlockingImplError<ERR>> {
+    /// Do a read, and return button and axis values relative to calibration
+    pub fn read(&mut self) -> Result<NunchukReadingCalibrated, BlockingImplError<ERR>> {
         Ok(NunchukReadingCalibrated::new(
-            self.read_report_blocking()?,
+            self.read_uncalibrated()?,
             &self.calibration,
         ))
     }
-
 }

--- a/wii-ext/src/lib.rs
+++ b/wii-ext/src/lib.rs
@@ -1,3 +1,19 @@
+#![doc = include_str!("../../README.md")]
+// See https://www.raphnet-tech.com/support/classic_controller_high_res/ for data on high-precision mode
+
+// Abridged version of the above:
+// To enable High Resolution Mode, you simply write 0x03 to address 0xFE in the extension controller memory.
+// Then you poll the controller by reading 8 bytes at address 0x00 instead of only 6.
+// You can also restore the original format by writing the original value back to address 0xFE at any time.
+//
+// Classic mode:
+// http://wiibrew.org/wiki/Wiimote/Extension_Controllers/Classic_Controller
+//
+// See `decode_classic_report` and `decode_classic_hd_report` for data format
+//
+// The nunchuk portion of this crate is derived from
+// https://github.com/rust-embedded/rust-i2cdev/blob/master/examples/nunchuck.rs
+// which is Copyright 2015, Paul Osborne <osbpau@gmail.com>
 #![cfg_attr(not(test), no_std)]
 
 /// Async I2C implementations

--- a/wii-ext/tests/classic_hd.rs
+++ b/wii-ext/tests/classic_hd.rs
@@ -51,7 +51,7 @@ macro_rules! assert_joystick_hd {
                 let delay = NoopDelay::new();
                 let mut classic = Classic::new(i2c.clone(), delay).unwrap();
                 classic.enable_hires().unwrap();
-                let input = classic.read_blocking().unwrap();
+                let input = classic.read().unwrap();
 
                 assert!(
                     ($lxl..=$lxh).contains(&input.joystick_left_x),

--- a/wii-ext/tests/classic_pdp_clone.rs
+++ b/wii-ext/tests/classic_pdp_clone.rs
@@ -54,7 +54,7 @@ fn classic_idle() {
     let mut i2c = i2c::Mock::new(&expectations);
     let delay = NoopDelay::new();
     let mut classic = Classic::new(i2c.clone(), delay).unwrap();
-    let report = classic.read_report().unwrap();
+    let report = classic.read_uncalibrated().unwrap();
     assert_digital_eq(report, ClassicReading::default());
     i2c.done();
 }
@@ -102,7 +102,7 @@ macro_rules! assert_button_fn {
                 let mut i2c = i2c::Mock::new(&expectations);
                 let delay = NoopDelay::new();
                 let mut classic = Classic::new(i2c.clone(), delay).unwrap();
-                let input = classic.read_report_blocking().unwrap();
+                let input = classic.read_uncalibrated().unwrap();
                 assert_digital_eq(input, ClassicReading {
                     $x: true,
                     ..Default::default()
@@ -149,7 +149,7 @@ fn classic_calibrated_idle() {
     let mut i2c = i2c::Mock::new(&expectations);
     let delay = NoopDelay::new();
     let mut classic = Classic::new(i2c.clone(), delay).unwrap();
-    let input = classic.read_blocking().unwrap();
+    let input = classic.read().unwrap();
     assert_eq!(input.joystick_left_x, 0);
     assert_eq!(input.joystick_left_y, 0);
     assert_eq!(input.joystick_right_x, 0);
@@ -176,7 +176,7 @@ fn classic_calibrated_joy_left() {
     let mut i2c = i2c::Mock::new(&expectations);
     let delay = NoopDelay::new();
     let mut classic = Classic::new(i2c.clone(), delay).unwrap();
-    let input = classic.read_blocking().unwrap();
+    let input = classic.read().unwrap();
 
     assert!(
         (i8::MIN..-AXIS_MAX).contains(&input.joystick_left_x),
@@ -239,7 +239,7 @@ macro_rules! assert_joysticks {
                 let mut i2c = i2c::Mock::new(&expectations);
                 let delay = NoopDelay::new();
                 let mut classic = Classic::new(i2c.clone(), delay).unwrap();
-                let input = classic.read_blocking().unwrap();
+                let input = classic.read().unwrap();
 
                 assert!(
                     ($lxl..=$lxh).contains(&input.joystick_left_x),

--- a/wii-ext/tests/classic_pdp_clone.rs
+++ b/wii-ext/tests/classic_pdp_clone.rs
@@ -54,7 +54,7 @@ fn classic_idle() {
     let mut i2c = i2c::Mock::new(&expectations);
     let delay = NoopDelay::new();
     let mut classic = Classic::new(i2c.clone(), delay).unwrap();
-    let report = classic.read_report_blocking().unwrap();
+    let report = classic.read_report().unwrap();
     assert_digital_eq(report, ClassicReading::default());
     i2c.done();
 }

--- a/wii-ext/tests/classic_pdp_clone_hd.rs
+++ b/wii-ext/tests/classic_pdp_clone_hd.rs
@@ -51,7 +51,7 @@ macro_rules! assert_joystick_hd {
                 let delay = NoopDelay::new();
                 let mut classic = Classic::new(i2c.clone(), delay).unwrap();
                 classic.enable_hires().unwrap();
-                let input = classic.read_blocking().unwrap();
+                let input = classic.read().unwrap();
 
                 assert!(
                     ($lxl..=$lxh).contains(&input.joystick_left_x),

--- a/wii-ext/tests/classic_pro.rs
+++ b/wii-ext/tests/classic_pro.rs
@@ -54,7 +54,7 @@ fn classic_idle() {
     let mut i2c = i2c::Mock::new(&expectations);
     let delay = NoopDelay::new();
     let mut classic = Classic::new(i2c.clone(), delay).unwrap();
-    let report = classic.read_report().unwrap();
+    let report = classic.read_uncalibrated().unwrap();
     assert_digital_eq(report, ClassicReading::default());
     i2c.done();
 }
@@ -102,7 +102,7 @@ macro_rules! assert_button_fn {
                 let mut i2c = i2c::Mock::new(&expectations);
                 let delay = NoopDelay::new();
                 let mut classic = Classic::new(i2c.clone(), delay).unwrap();
-                let input = classic.read_report_blocking().unwrap();
+                let input = classic.read_uncalibrated().unwrap();
                 assert_digital_eq(input, ClassicReading {
                     $x: true,
                     ..Default::default()
@@ -149,7 +149,7 @@ fn classic_calibrated_idle() {
     let mut i2c = i2c::Mock::new(&expectations);
     let delay = NoopDelay::new();
     let mut classic = Classic::new(i2c.clone(), delay).unwrap();
-    let input = classic.read_blocking().unwrap();
+    let input = classic.read().unwrap();
     assert_eq!(input.joystick_left_x, 0);
     assert_eq!(input.joystick_left_y, 0);
     assert_eq!(input.joystick_right_x, 0);
@@ -176,7 +176,7 @@ fn classic_calibrated_joy_left() {
     let mut i2c = i2c::Mock::new(&expectations);
     let delay = NoopDelay::new();
     let mut classic = Classic::new(i2c.clone(), delay).unwrap();
-    let input = classic.read_blocking().unwrap();
+    let input = classic.read().unwrap();
 
     assert!(
         (i8::MIN..-AXIS_MAX).contains(&input.joystick_left_x),
@@ -240,7 +240,7 @@ macro_rules! assert_joysticks {
                 let mut i2c = i2c::Mock::new(&expectations);
                 let delay = NoopDelay::new();
                 let mut classic = Classic::new(i2c.clone(), delay).unwrap();
-                let input = classic.read_blocking().unwrap();
+                let input = classic.read().unwrap();
 
                 assert!(
                     ($lxl..=$lxh).contains(&input.joystick_left_x),

--- a/wii-ext/tests/classic_pro.rs
+++ b/wii-ext/tests/classic_pro.rs
@@ -54,7 +54,7 @@ fn classic_idle() {
     let mut i2c = i2c::Mock::new(&expectations);
     let delay = NoopDelay::new();
     let mut classic = Classic::new(i2c.clone(), delay).unwrap();
-    let report = classic.read_report_blocking().unwrap();
+    let report = classic.read_report().unwrap();
     assert_digital_eq(report, ClassicReading::default());
     i2c.done();
 }

--- a/wii-ext/tests/classic_pro_hd.rs
+++ b/wii-ext/tests/classic_pro_hd.rs
@@ -51,7 +51,7 @@ macro_rules! assert_joystick_hd {
                 let delay = NoopDelay::new();
                 let mut classic = Classic::new(i2c.clone(), delay).unwrap();
                 classic.enable_hires().unwrap();
-                let input = classic.read_blocking().unwrap();
+                let input = classic.read().unwrap();
 
                 assert!(
                     ($lxl..=$lxh).contains(&input.joystick_left_x),

--- a/wii-ext/tests/classic_regular.rs
+++ b/wii-ext/tests/classic_regular.rs
@@ -52,7 +52,7 @@ fn classic_idle() {
     let mut i2c = i2c::Mock::new(&expectations);
     let delay = NoopDelay::new();
     let mut classic = Classic::new(i2c.clone(), delay).unwrap();
-    let report = classic.read_report().unwrap();
+    let report = classic.read_uncalibrated().unwrap();
     assert_digital_eq(report, ClassicReading::default());
     i2c.done();
 }
@@ -100,7 +100,7 @@ macro_rules! assert_button_fn {
                 let mut i2c = i2c::Mock::new(&expectations);
                 let delay = NoopDelay::new();
                 let mut classic = Classic::new(i2c.clone(), delay).unwrap();
-                let input = classic.read_report_blocking().unwrap();
+                let input = classic.read_uncalibrated().unwrap();
                 assert_digital_eq(input, ClassicReading {
                     $x: true,
                     ..Default::default()
@@ -147,7 +147,7 @@ fn classic_calibrated_idle() {
     let mut i2c = i2c::Mock::new(&expectations);
     let delay = NoopDelay::new();
     let mut classic = Classic::new(i2c.clone(), delay).unwrap();
-    let input = classic.read_blocking().unwrap();
+    let input = classic.read().unwrap();
     assert_eq!(input.joystick_left_x, 0);
     assert_eq!(input.joystick_left_y, 0);
     assert_eq!(input.joystick_right_x, 0);
@@ -177,7 +177,7 @@ fn classic_calibrated_joy_left() {
     let mut i2c = i2c::Mock::new(&expectations);
     let delay = NoopDelay::new();
     let mut classic = Classic::new(i2c.clone(), delay).unwrap();
-    let input = classic.read_blocking().unwrap();
+    let input = classic.read().unwrap();
 
     assert!(
         (i8::MIN..=-AXIS_MAX).contains(&input.joystick_left_x),
@@ -240,7 +240,7 @@ macro_rules! assert_joysticks {
                 let mut i2c = i2c::Mock::new(&expectations);
                 let delay = NoopDelay::new();
                 let mut classic = Classic::new(i2c.clone(), delay).unwrap();
-                let input = classic.read_blocking().unwrap();
+                let input = classic.read().unwrap();
 
                 assert!(
                     ($lxl..=$lxh).contains(&input.joystick_left_x),

--- a/wii-ext/tests/classic_regular.rs
+++ b/wii-ext/tests/classic_regular.rs
@@ -52,7 +52,7 @@ fn classic_idle() {
     let mut i2c = i2c::Mock::new(&expectations);
     let delay = NoopDelay::new();
     let mut classic = Classic::new(i2c.clone(), delay).unwrap();
-    let report = classic.read_report_blocking().unwrap();
+    let report = classic.read_report().unwrap();
     assert_digital_eq(report, ClassicReading::default());
     i2c.done();
 }

--- a/wii-ext/tests/nunchuk.rs
+++ b/wii-ext/tests/nunchuk.rs
@@ -34,7 +34,7 @@ fn nunchuck_idle() {
     let mut mock = i2c::Mock::new(&expectations);
     let delay = NoopDelay::new();
     let mut nc = Nunchuk::new(mock.clone(), delay).unwrap();
-    let report = nc.read_blocking().unwrap();
+    let report = nc.read().unwrap();
     assert!(!report.button_c);
     assert!(!report.button_z);
     mock.done();
@@ -58,7 +58,7 @@ fn nunchuck_idle_calibrated() {
     let mut mock = i2c::Mock::new(&expectations);
     let delay = NoopDelay::new();
     let mut nc = Nunchuk::new(mock.clone(), delay).unwrap();
-    let report = nc.read_blocking().unwrap();
+    let report = nc.read().unwrap();
     assert!(!report.button_c);
     assert!(!report.button_z);
     assert_eq!(report.joystick_x, 0);
@@ -84,7 +84,7 @@ fn nunchuck_left_calibrated() {
     let mut mock = i2c::Mock::new(&expectations);
     let delay = NoopDelay::new();
     let mut nc = Nunchuk::new(mock.clone(), delay).unwrap();
-    let report = nc.read_blocking().unwrap();
+    let report = nc.read().unwrap();
     assert!(!report.button_c);
     assert!(!report.button_z);
     assert!(report.joystick_x < -AXIS_MAX, "x = {}", report.joystick_x);
@@ -111,7 +111,7 @@ fn nunchuck_right_calibrated() {
     let mut mock = i2c::Mock::new(&expectations);
     let delay = NoopDelay::new();
     let mut nc = Nunchuk::new(mock.clone(), delay).unwrap();
-    let report = nc.read_blocking().unwrap();
+    let report = nc.read().unwrap();
     assert!(!report.button_c);
     assert!(!report.button_z);
     assert!(report.joystick_x > AXIS_MAX, "x = {}", report.joystick_x);
@@ -138,7 +138,7 @@ fn nunchuck_up_calibrated() {
     let mut mock = i2c::Mock::new(&expectations);
     let delay = NoopDelay::new();
     let mut nc = Nunchuk::new(mock.clone(), delay).unwrap();
-    let report = nc.read_blocking().unwrap();
+    let report = nc.read().unwrap();
     assert!(!report.button_c);
     assert!(!report.button_z);
     assert!(report.joystick_y > AXIS_MAX, "y = {}", report.joystick_y);
@@ -165,7 +165,7 @@ fn nunchuck_down_calibrated() {
     let mut mock = i2c::Mock::new(&expectations);
     let delay = NoopDelay::new();
     let mut nc = Nunchuk::new(mock.clone(), delay).unwrap();
-    let report = nc.read_blocking().unwrap();
+    let report = nc.read().unwrap();
     assert!(!report.button_c);
     assert!(!report.button_z);
     assert!(report.joystick_y < -AXIS_MAX, "y = {}", report.joystick_y);
@@ -195,10 +195,10 @@ fn nunchuck_idle_repeat() {
     let delay = NoopDelay::new();
     let mut nc = Nunchuk::new(mock.clone(), delay).unwrap();
 
-    let report = nc.read_report_blocking().unwrap();
+    let report = nc.read_uncalibrated().unwrap();
     assert!(!report.button_c);
     assert!(!report.button_z);
-    let report = nc.read_report_blocking().unwrap();
+    let report = nc.read_uncalibrated().unwrap();
     assert!(!report.button_c);
     assert!(!report.button_z);
     mock.done();
@@ -223,7 +223,7 @@ fn nunchuck_btn_c() {
     let delay = NoopDelay::new();
     let mut nc = Nunchuk::new(mock.clone(), delay).unwrap();
 
-    let report = nc.read_report_blocking().unwrap();
+    let report = nc.read_uncalibrated().unwrap();
     assert!(report.button_c);
     assert!(!report.button_z);
     mock.done();
@@ -248,7 +248,7 @@ fn nunchuck_btn_z() {
     let delay = NoopDelay::new();
     let mut nc = Nunchuk::new(mock.clone(), delay).unwrap();
 
-    let report = nc.read_report_blocking().unwrap();
+    let report = nc.read_uncalibrated().unwrap();
     assert!(!report.button_c);
     assert!(report.button_z);
     mock.done();


### PR DESCRIPTION
- Renamed ClassicAsync/NunchukAsync to Classic/Nunchuk.
- Renamed read_report/read_report_blocking (and friends) to read and read_uncalibrated.
- Various differences between async and sync removed.
- Redundant functions removed.
- Docs cleanup.